### PR TITLE
Export GitHub sha tag for auto deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,8 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             cd /opt/notes-api
+            export IMAGE_TAG=${{ github.event.workflow_run.head_sha }}
             docker compose pull
             docker compose up -d
             docker compose exec -T app npx prisma db push
-            echo "Deployment complete!"
+            echo "Deployment complete: $IMAGE_TAG"

--- a/README.md
+++ b/README.md
@@ -76,3 +76,5 @@ Ablauf:
 Nach jedem Push auf main wird automatisch ein aktuelles, versioniertes Docker Image bei ghcr erstellt.
 
 ![CI/CD Architektur](github-workflow-diagram.png)
+
+<!-- Test row for build -->


### PR DESCRIPTION
Export tag, so that server can paste the actual commit sha for building the image container